### PR TITLE
fix: ARM64 Linux buffer size test expectation

### DIFF
--- a/internal/core/platform_detector_test.go
+++ b/internal/core/platform_detector_test.go
@@ -408,8 +408,11 @@ func TestPlatformSpecificSettings(t *testing.T) {
 	switch info.OS {
 	case "linux":
 		// Linux should have specific optimizations
-		if !isLowEnd && info.Optimizations.BufferSize != 512*1024 {
-			t.Errorf("Linux should use 512KB buffers, got %d", info.Optimizations.BufferSize)
+		// ARM64 Linux uses 128KB buffers, others use 512KB
+		if !isLowEnd && info.IsARM && info.Optimizations.BufferSize != 128*1024 {
+			t.Errorf("ARM64 Linux should use 128KB buffers, got %d", info.Optimizations.BufferSize)
+		} else if !isLowEnd && !info.IsARM && info.Optimizations.BufferSize != 512*1024 {
+			t.Errorf("x86_64 Linux should use 512KB buffers, got %d", info.Optimizations.BufferSize)
 		}
 		if !info.Optimizations.UseSendfile {
 			t.Error("Linux should support sendfile")


### PR DESCRIPTION
## Summary
- Fixes ARM64 QEMU test failures in CI
- Corrects buffer size expectations for ARM64 Linux architecture

## Problem
The test was failing on ARM64 Linux with:
```
platform_detector_test.go:412: Linux should use 512KB buffers, got 131072
```

ARM64 Linux is configured to use 128KB buffers for optimization, but the test expected all Linux systems to use 512KB.

## Solution
- Update test to check for architecture-specific buffer sizes
- ARM64 Linux: expects 128KB buffers
- x86_64 Linux: expects 512KB buffers

## Test Results
- ✅ Tests pass locally on macOS ARM64
- ✅ Should fix ARM64 QEMU tests in CI

Fixes CI failure: https://github.com/forest6511/gdl/actions/runs/17932859853/job/50993516400