### PR TITLE
fix: prevent duplicate ARM Platform Tests execution

### DIFF
--- a/.github/workflows/arm-platform.yml
+++ b/.github/workflows/arm-platform.yml
@@ -3,12 +3,6 @@ name: ARM Platform Tests
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'internal/core/platform_*.go'
-      - '.github/workflows/arm-platform.yml'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
Fixes duplicate workflow execution that causes ARM64 QEMU tests to be cancelled.

## Problem
When pushing to main branch, two workflows are triggered:
1. **ARM Platform Tests** (standalone) 
2. **Main CI/CD Pipeline** (which also runs ARM Platform Tests internally)

These conflict because of the concurrency setting, causing the error:
```
Canceling since a higher priority waiting request for arm-platform-refs/heads/main exists
```

## Solution
- Remove `push` trigger from `arm-platform.yml`
- Keep only:
  - `workflow_call` (called by Main CI/CD Pipeline)
  - `workflow_dispatch` (manual runs)
  - `pull_request` (PR-specific runs)

## Result
- Only one ARM Platform Tests instance runs on main branch pushes (via Main CI/CD)
- No more cancellation conflicts
- ARM64 QEMU tests can complete successfully

## Test Plan
- [x] Verify PR triggers only one ARM Platform Tests
- [ ] After merge, verify main branch triggers only via Main CI/CD Pipeline
- [ ] Confirm ARM64 QEMU test completes without cancellation

Fixes: https://github.com/forest6511/gdl/actions/runs/17933261920/job/50994381038