### PR TITLE
fix: Add binutils-gold to ARM64 Docker image

### DIFF
--- a/.github/workflows/arm-platform.yml
+++ b/.github/workflows/arm-platform.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           cat > Dockerfile.arm64test << 'EOF'
           FROM --platform=linux/arm64 golang:1.24-alpine
-          RUN apk add --no-cache git gcc musl-dev
+          RUN apk add --no-cache git gcc musl-dev binutils-gold
           WORKDIR /app
           COPY go.mod go.sum ./
           RUN go mod download

--- a/Dockerfile.arm64test
+++ b/Dockerfile.arm64test
@@ -1,0 +1,12 @@
+FROM --platform=linux/arm64 golang:1.24-alpine
+RUN apk add --no-cache git gcc musl-dev binutils-gold
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Run platform-specific tests
+RUN go test -v ./internal/core -run "TestDetectPlatform|TestPlatform|TestARM"
+# Build the binary
+RUN go build -v ./cmd/gdl/
+# Verify the binary
+RUN ./gdl --version


### PR DESCRIPTION
## Summary
- Add binutils-gold package to ARM64 Docker test image
- Fixes 'cannot find ld' linker error during Go build
- Resolves ARM64 QEMU test failures in CI

## Problem
The ARM64 QEMU tests were failing with:
```
collect2: fatal error: cannot find 'ld'
```

## Solution
Added `binutils-gold` package to provide the gold linker required by Go build process on Alpine Linux ARM64.

## Test Results
✅ Docker build successful locally
✅ Tests pass in ARM64 container
✅ Binary builds successfully

Fixes CI failure: https://github.com/forest6511/gdl/actions/runs/17933665718/job/50995612085